### PR TITLE
delete race condition

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -148,7 +148,12 @@ async fn calcagebra(
         .await)
         .is_some()
     {
-        reply.delete(Context::Application(ctx)).await?;
+        // Ignore "Unknown Message" errors from race conditions because people suck
+        if let Err(err) = reply.delete(Context::Application(ctx)).await {
+            if !err.to_string().contains("Unknown Message") {
+                return Err(err);
+            }
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,7 +148,7 @@ async fn calcagebra(
         .await)
         .is_some()
     {
-        // Ignore "Unknown Message" errors from race conditions because people suck
+        // Silently ignore "Unknown Message" errors caused by race conditions
         if let Err(err) = reply.delete(Context::Application(ctx)).await {
             if !err.to_string().contains("Unknown Message") {
                 return Err(err);


### PR DESCRIPTION
This pull request updates error handling in the `calcagebra` function in `src/main.rs` to prevent failures caused by race conditions. The change ensures that "Unknown Message" errors are ignored during the deletion of a reply.

Error handling improvement:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL151-R156): Modified the `reply.delete` call to catch and ignore "Unknown Message" errors, preventing race condition-related failures.